### PR TITLE
Changes to healsparse methods from camelCase to separated by '_'.

### DIFF
--- a/desmasks/loadreg.py
+++ b/desmasks/loadreg.py
@@ -53,9 +53,9 @@ def load_regions(fname, doplot=False, verbose=False, **kw):
         from .plotting import plotrand
 
         nside = 2**17
-        smap = hs.HealSparseMap.makeEmpty(
-            nsideCoverage=32,
-            nsideSparse=nside,
+        smap = hs.HealSparseMap.make_empty(
+            nside_coverage=32,
+            nside_sparse=nside,
             dtype=np.int16,
             sentinel=0,
         )

--- a/desmasks/masks.py
+++ b/desmasks/masks.py
@@ -31,8 +31,8 @@ class TileMask(object):
         check if the input positions are masked
         """
 
-        mask_values = self._mask_map.getValueRaDec(ra, dec)
-        bounds_values = self._bounds_map.getValueRaDec(ra, dec)
+        mask_values = self._mask_map.get_values_pos(ra, dec)
+        bounds_values = self._bounds_map.get_values_pos(ra, dec)
 
         return (
             (mask_values > 0) | (bounds_values == 0)
@@ -50,4 +50,4 @@ class TileMask(object):
         """
         get mask values (not from bounds)
         """
-        return self._mask_map.getValueRaDec(ra, dec)
+        return self._mask_map.get_values_pos(ra, dec)

--- a/desmasks/plotting.py
+++ b/desmasks/plotting.py
@@ -51,7 +51,7 @@ def plot_by_val(smap, ra, dec, use_rainbow=False, show=False, **kw):
 
     size = kw.pop('size', 1)
 
-    vals = smap.getValueRaDec(ra, dec)
+    vals = smap.get_values_pos(ra, dec)
     uvals = np.unique(vals)
     print('uvals: %s' % repr(uvals))
     if use_rainbow:
@@ -131,17 +131,17 @@ def plotrand(smap,
         if rng is None:
             rng = np.random.RandomState()
 
-        vpix = smap.validPixels
+        vpix = smap.valid_pixels
         if vpix.size > nrand:
             isub = rng.randint(0, vpix.size, size=nrand)
             sub = vpix[isub]
         else:
             sub = vpix
 
-        ra, dec = hp.pix2ang(smap.nsideSparse, sub, nest=True, lonlat=True)
+        ra, dec = hp.pix2ang(smap.nside_sparse, sub, nest=True, lonlat=True)
 
     else:
-        ra, dec = hs.makeUniformRandomsFast(smap, nrand, rng=rng)
+        ra, dec = hs.make_uniform_randoms_fast(smap, nrand, rng=rng)
 
     if 'aspect_ratio' not in kw:
         kw['aspect_ratio'] = (dec.max()-dec.min())/(ra.max()-ra.min())


### PR DESCRIPTION
Should work with healsparse v1.2.0.
Most changes were straightforward, except `healsparse.HealSparseMap.getValueRaDec` has turned into `healsparse.HealSparseMap.get_values_pos`